### PR TITLE
New Snippet for Multiline Shortcode Template w/ param

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,19 @@ To trigger the snippets in Markdown you can use `^Space` [Snippets for Markdown]
 
 ## Markdown
 
-| Prefix            | Description                 |
-| ----------------- | --------------------------- |
-| h-figure          | Figure Shortcode            |
-| h-gist            | Gist Shortcode              |
-| h-highlight       | Highlight Shortcode         |
-| h-instagram       | Instagram Shortcode         |
-| h-shortcode       | Shortcode Template          |
-| h-shortcode-param | Shortcode Template w/ param |
-| h-ref             | Ref Shortcode               |
-| h-tweet           | Tweet Shortcode             |
-| h-vimeo           | Vimeo Shortcode             |
-| h-youtube         | Youtube Shortcode           |
+| Prefix                | Description                           |
+| --------------------- | ------------------------------------- |
+| h-figure              | Figure Shortcode                      |
+| h-gist                | Gist Shortcode                        |
+| h-highlight           | Highlight Shortcode                   |
+| h-instagram           | Instagram Shortcode                   |
+| h-shortcode           | Shortcode Template                    |
+| h-shortcode-param     | Shortcode Template w/ param           |
+| h-shortcode-multiline | Multiline Shortcode Template w/ param |
+| h-ref                 | Ref Shortcode                         |
+| h-tweet               | Tweet Shortcode                       |
+| h-vimeo               | Vimeo Shortcode                       |
+| h-youtube             | Youtube Shortcode                     |
 
 ## Function
 

--- a/snippets/hugo-markdown.json
+++ b/snippets/hugo-markdown.json
@@ -33,6 +33,15 @@
     "body": ["{{< ${1:shortcode} ${2:param} >}}"],
     "description": "Shortcode Template w/ param"
   },
+  "hugo-shortcode-multiline": {
+    "prefix": "h-shortcode-multiline",
+    "body": [
+      "{{< ${1:shortcode} ${2:param} >}}",
+      "${0}",
+      "{{ /${1:shortcode} }}"
+    ],
+    "description": "Multiline Shortcode Template w/ param"
+  },
   "hugo-ref": {
     "prefix": "h-ref",
     "body": ["[${1:Text}]({{< ref \"${2:pageName}.md\" >}})"],


### PR DESCRIPTION
This is to produce new snippets of shortcode that need multiple lines. Example is

{{< notice warning >}}

{{< /notice >}}